### PR TITLE
Avoid bug when converting tpks that have entire zoom levels of empty tiles

### DIFF
--- a/tpkutils/__init__.py
+++ b/tpkutils/__init__.py
@@ -341,10 +341,16 @@ class TPK(object):
             zoom = list(zoom)
             zoom.sort()
 
-            real_zooms = set()  # Zooms for which at least some tiles have not been dropped
+            real_zooms = (
+                set()
+            )  # Zooms for which at least some tiles have not been dropped
+
             def tile_generator():
                 for tile in self.read_tiles(zoom, flip_y=True):
-                    if drop_empty and hashlib.sha1(tile.data).hexdigest() in EMPTY_TILES:
+                    if (
+                        drop_empty
+                        and hashlib.sha1(tile.data).hexdigest() in EMPTY_TILES
+                    ):
                         continue
                     real_zooms.add(tile.z)
                     yield tile

--- a/tpkutils/__init__.py
+++ b/tpkutils/__init__.py
@@ -337,13 +337,10 @@ class TPK(object):
                 zoom = self.zoom_levels
             elif isinstance(zoom, int):
                 zoom = [zoom]
+            zoom = sorted(zoom)
 
-            zoom = list(zoom)
-            zoom.sort()
-
-            real_zooms = (
-                set()
-            )  # Zooms for which at least some tiles have not been dropped
+            # Zooms for which at least some tiles have not been dropped
+            real_zooms = set()
 
             def tile_generator():
                 for tile in self.read_tiles(zoom, flip_y=True):
@@ -357,8 +354,7 @@ class TPK(object):
 
             mbtiles.write_tiles(tile_generator())
 
-            zoom = list(real_zooms)
-            zoom.sort()
+            zoom = sorted(real_zooms)
 
             if tile_bounds:
                 # Calculate bounds based on maximum zoom to be exported


### PR DESCRIPTION
TPKs may have zoom levels for which all tiles are empty. For example, a tile package may have non-empty tiles up to level 16, but then have levels 17-23 filled with empty tiles (I'm unsure what generation settings at cause this but have seen such packages in the wild).

This PR avoids an exception caused by this situation by refining the available zooms (and thus the max zoom) according to non-empty tiles so that the `highest_zoom` value represents a zoom level actually present in the newly-created mbtiles database when `--drop-emtpy` is used.